### PR TITLE
fix error about missing readme when pip installing from sdist

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,55 +1,15 @@
 #!/usr/bin/env python3
 
-import tomli
-import tomli_w
-import shutil
 import subprocess
 import sys
 from pathlib import Path
 
 
 root_dir = Path(__file__).parent.resolve()
-crate_dir = root_dir / "resvg" / "crates" / "resvg"
 dist_dir = root_dir / "dist"
-cargo_manifest_path = crate_dir / "Cargo.toml"
-pyproject_toml_path = root_dir / "pyproject.toml"
-py_readme = root_dir / "README.rst"
 
 
 def main():
-    # maturin expects the 'pyproject.toml' file to be located in the same
-    # directory as Cargo.toml, so we copy it there
-    shutil.copyfile(pyproject_toml_path, crate_dir / "pyproject.toml")
-    # We also want to include our own README.rst in the source distribution,
-    # alongside the original README.md
-    shutil.copyfile(py_readme, crate_dir / "README.python.rst")
-
-    # resvg's top-level Cargo.toml declares a workspace with explicit members
-    # (subfolders) and each members' Cargo.toml also explicitly points back to the
-    # root directory in the package.workspace key. Maturin doesn't like this setup
-    # (it complains cargo metadata can't find the members' manifests), so below
-    # I modify the manifests such that the 'members' key of [workspace] section from
-    # the root Cargo.toml, as well as the 'workspace' key of [package] section of the
-    # members' Cargo.toml, are both omitted and implicit. Cargo can figure these out
-    # automatically, see:
-    # https://rust-lang.github.io/rfcs/1525-cargo-workspace.html#implicit-relations
-    cargo_manifest = tomli.load(cargo_manifest_path.open("rb"))
-    if "workspace" in cargo_manifest and "members" in cargo_manifest["workspace"]:
-        workspace_members = cargo_manifest["workspace"].pop("members")
-        for member in workspace_members:
-            member_dir = crate_dir / member
-            assert member_dir.is_dir()
-            member_manifest = tomli.load((member_dir / "Cargo.toml").open("rb"))
-            if (
-                "package" in member_manifest
-                and "workspace" in member_manifest["package"]
-            ):
-                workspace_root = member_dir / member_manifest["package"]["workspace"]
-                assert workspace_root.resolve() == crate_dir
-                del member_manifest["package"]["workspace"]
-                tomli_w.dump(member_manifest, (member_dir / "Cargo.toml").open("wb"))
-        tomli_w.dump(cargo_manifest, cargo_manifest_path.open("wb"))
-
     try:
         cmd = {
             "sdist": ["maturin", "sdist"],
@@ -64,7 +24,7 @@ def main():
         args.remove("--universal2")
 
     return subprocess.call(
-        cmd + ["-o", str(dist_dir)] + args, cwd=str(crate_dir)
+        cmd + ["-o", str(dist_dir)] + args
     )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,22 +3,18 @@ requires = ["maturin>=1.7.4,<1.8"]
 build-backend = "maturin"
 
 [tool.maturin]
-# If I use the 'manifest-path' option, then maturin takes all the metadata from the
-# Cargo.toml and ignores the metadata from pyproject.toml; it also fails to build
-# a sdist for some reason. Only when pyproject.toml is in the same directory as
-# Cargo.toml, everything works.
-# manifest-path = "resvg/Cargo.toml"
+manifest-path = "resvg/crates/resvg/Cargo.toml"
 bindings = "bin"
-sdist-include = ["README.python.rst"]
+include = ["README.rst"]
 
 [project]
 name = "resvg-cli"
 # comment out 'version' to use the same as Cargo.toml, only override if needed
 # (e.g. for a post-release to fix some packaging issues with a previous release)
-version = "0.44.0b1"
+version = "0.44.0b2"
 description = "Precompiled binaries for the 'resvg' CLI tool, from the homonymous SVG rendering library."
 maintainers = [{name = "Cosimo Lupo", email = "cosimo@anthrotype.com"}]
-readme = {file = "README.python.rst"}
+readme = {file = "README.rst"}
 
 [project.urls]
 repository = "https://github.com/anthrotype/resvg-wheels"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 maturin
-tomli
-tomli-w
 twine


### PR DESCRIPTION
the sdist I uploaded with the previous pre-release at https://pypi.org/project/resvg-cli/0.44.0b1/#files was broken

This PR also removes various hacks for older maturin which are no longer needed.

After this pip install'ing from the source distribution should finally work again.